### PR TITLE
Allows inbound firewall rules

### DIFF
--- a/android/app/src/main/kotlin/net/defined/mobile_nebula/MainActivity.kt
+++ b/android/app/src/main/kotlin/net/defined/mobile_nebula/MainActivity.kt
@@ -18,7 +18,7 @@ import io.flutter.plugins.GeneratedPluginRegistrant
 const val TAG = "nebula"
 const val VPN_PERMISSIONS_CODE = 0x0F
 const val VPN_START_CODE = 0x10
-const val CHANNEL = "net.defined.mobileNebula/NebulaVpnService"
+const val CHANNEL = "org.mooco.mobilenebula/NebulaVpnService"
 
 class MainActivity: FlutterActivity() {
     private var sites: Sites? = null

--- a/ios/NebulaNetworkExtension/Keychain.swift
+++ b/ios/NebulaNetworkExtension/Keychain.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-let groupName = "group.net.defined.mobileNebula"
+let groupName = "group.org.mooco.mobilenebula"
 
 class KeyChain {
     class func save(key: String, data: Data) -> Bool {
@@ -35,7 +35,7 @@ class KeyChain {
             return nil
         }
     }
-    
+
     class func delete(key: String) -> Bool {
        let query: [String: Any] = [
            kSecClass as String       : kSecClassGenericPassword,
@@ -64,4 +64,3 @@ extension Data {
         return self.withUnsafeBytes { $0.load(as: T.self) }
     }
 }
-

--- a/ios/NebulaNetworkExtension/NebulaNetworkExtension.entitlements
+++ b/ios/NebulaNetworkExtension/NebulaNetworkExtension.entitlements
@@ -8,11 +8,11 @@
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.net.defined.mobileNebula</string>
+		<string>group.org.mooco.mobilenebula</string>
 	</array>
 	<key>keychain-access-groups</key>
 	<array>
-		<string>$(AppIdentifierPrefix)group.net.defined.mobileNebula</string>
+		<string>$(AppIdentifierPrefix)group.org.mooco.mobilenebula</string>
 	</array>
 </dict>
 </plist>

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -282,12 +282,12 @@
 				TargetAttributes = {
 					43AA89532444DA6500EDC39C = {
 						CreatedOnToolsVersion = 11.4;
-						DevelopmentTeam = 576H3XS7FP;
+						DevelopmentTeam = 55X6RF4VV8;
 						ProvisioningStyle = Automatic;
 					};
 					97C146ED1CF9000F007C117D = {
 						CreatedOnToolsVersion = 7.3.1;
-						DevelopmentTeam = 576H3XS7FP;
+						DevelopmentTeam = 55X6RF4VV8;
 						LastSwiftMigration = 1100;
 					};
 				};
@@ -580,7 +580,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 576H3XS7FP;
+				DEVELOPMENT_TEAM = 55X6RF4VV8;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -595,7 +595,7 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				MARKETING_VERSION = 0.0.41;
-				PRODUCT_BUNDLE_IDENTIFIER = net.defined.mobileNebula;
+				PRODUCT_BUNDLE_IDENTIFIER = org.mooco.mobilenebula;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -615,7 +615,7 @@
 				CODE_SIGN_ENTITLEMENTS = NebulaNetworkExtension/NebulaNetworkExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 576H3XS7FP;
+				DEVELOPMENT_TEAM = 55X6RF4VV8;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -629,7 +629,7 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "";
-				PRODUCT_BUNDLE_IDENTIFIER = net.defined.mobileNebula.NebulaNetworkExtension;
+				PRODUCT_BUNDLE_IDENTIFIER = org.mooco.mobilenebula.NebulaNetworkExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
@@ -651,7 +651,7 @@
 				CODE_SIGN_ENTITLEMENTS = NebulaNetworkExtension/NebulaNetworkExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 576H3XS7FP;
+				DEVELOPMENT_TEAM = 55X6RF4VV8;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -664,7 +664,7 @@
 				MARKETING_VERSION = 0.0.41;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "";
-				PRODUCT_BUNDLE_IDENTIFIER = net.defined.mobileNebula.NebulaNetworkExtension;
+				PRODUCT_BUNDLE_IDENTIFIER = org.mooco.mobilenebula.NebulaNetworkExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
@@ -684,7 +684,7 @@
 				CODE_SIGN_ENTITLEMENTS = NebulaNetworkExtension/NebulaNetworkExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 576H3XS7FP;
+				DEVELOPMENT_TEAM = 55X6RF4VV8;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -697,7 +697,7 @@
 				MARKETING_VERSION = 0.0.41;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "";
-				PRODUCT_BUNDLE_IDENTIFIER = net.defined.mobileNebula.NebulaNetworkExtension;
+				PRODUCT_BUNDLE_IDENTIFIER = org.mooco.mobilenebula.NebulaNetworkExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
@@ -820,7 +820,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 576H3XS7FP;
+				DEVELOPMENT_TEAM = 55X6RF4VV8;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -835,7 +835,7 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				MARKETING_VERSION = 0.0.41;
-				PRODUCT_BUNDLE_IDENTIFIER = net.defined.mobileNebula;
+				PRODUCT_BUNDLE_IDENTIFIER = org.mooco.mobilenebula;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -853,7 +853,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 576H3XS7FP;
+				DEVELOPMENT_TEAM = 55X6RF4VV8;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -868,7 +868,7 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				MARKETING_VERSION = 0.0.41;
-				PRODUCT_BUNDLE_IDENTIFIER = net.defined.mobileNebula;
+				PRODUCT_BUNDLE_IDENTIFIER = org.mooco.mobilenebula;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -5,7 +5,7 @@ import NetworkExtension
 import SwiftyJSON
 
 enum ChannelName {
-    static let vpn = "net.defined.mobileNebula/NebulaVpnService"
+    static let vpn = "org.mooco.mobilenebula/NebulaVpnService"
 }
 
 func MissingArgumentError(message: String, details: Any?) -> FlutterError {
@@ -15,84 +15,84 @@ func MissingArgumentError(message: String, details: Any?) -> FlutterError {
 @UIApplicationMain
 @objc class AppDelegate: FlutterAppDelegate {
     private var sites: Sites?
-    
+
     override func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
         GeneratedPluginRegistrant.register(with: self)
-        
+
         guard let controller = window?.rootViewController as? FlutterViewController else {
             fatalError("rootViewController is not type FlutterViewController")
         }
-        
+
         sites = Sites(messenger: controller.binaryMessenger)
         let channel = FlutterMethodChannel(name: ChannelName.vpn, binaryMessenger: controller.binaryMessenger)
-        
+
         channel.setMethodCallHandler({(call: FlutterMethodCall, result: @escaping FlutterResult) -> Void in
             switch call.method {
             case "nebula.parseCerts": return self.nebulaParseCerts(call: call, result: result)
             case "nebula.generateKeyPair": return self.nebulaGenerateKeyPair(result: result)
             case "nebula.renderConfig": return self.nebulaRenderConfig(call: call, result: result)
-                
+
             case "listSites": return self.listSites(result: result)
             case "deleteSite": return self.deleteSite(call: call, result: result)
             case "saveSite": return self.saveSite(call: call, result: result)
             case "startSite": return self.startSite(call: call, result: result)
             case "stopSite": return self.stopSite(call: call, result: result)
-                
+
             case "active.listHostmap": self.vpnRequest(command: "listHostmap", arguments: call.arguments, result: result)
             case "active.listPendingHostmap": self.vpnRequest(command: "listPendingHostmap", arguments: call.arguments, result: result)
             case "active.getHostInfo": self.vpnRequest(command: "getHostInfo", arguments: call.arguments, result: result)
             case "active.setRemoteForTunnel": self.vpnRequest(command: "setRemoteForTunnel", arguments: call.arguments, result: result)
             case "active.closeTunnel": self.vpnRequest(command: "closeTunnel", arguments: call.arguments, result: result)
-                
+
             case "share": Share.share(call: call, result: result)
             case "shareFile": Share.shareFile(call: call, result: result)
-                
+
             default:
                 result(FlutterMethodNotImplemented)
             }
         })
-        
+
         return super.application(application, didFinishLaunchingWithOptions: launchOptions)
     }
-    
+
     func nebulaParseCerts(call: FlutterMethodCall, result: FlutterResult) {
         guard let args = call.arguments as? Dictionary<String, String> else { return result(NoArgumentsError()) }
         guard let certs = args["certs"] else { return result(MissingArgumentError(message: "certs is a required argument")) }
-        
+
         var err: NSError?
         let json = MobileNebulaParseCerts(certs, &err)
         if (err != nil) {
             return result(CallFailedError(message: "Error while parsing certificate(s)", details: err!.localizedDescription))
         }
-        
+
         return result(json)
     }
-    
+
     func nebulaGenerateKeyPair(result: FlutterResult) {
         var err: NSError?
         let kp = MobileNebulaGenerateKeyPair(&err)
         if (err != nil) {
             return result(CallFailedError(message: "Error while generating key pairs", details: err!.localizedDescription))
         }
-        
+
         return result(kp)
     }
-    
+
     func nebulaRenderConfig(call: FlutterMethodCall, result: FlutterResult) {
         guard let config = call.arguments as? String else { return result(NoArgumentsError()) }
-        
+
         var err: NSError?
         let yaml = MobileNebulaRenderConfig(config, "<hidden>", &err)
         if (err != nil) {
             return result(CallFailedError(message: "Error while rendering config", details: err!.localizedDescription))
         }
-        
+
         return result(yaml)
     }
-    
+
     func listSites(result: @escaping FlutterResult) {
         self.sites?.loadSites { (sites, err) -> () in
             if (err != nil) {
@@ -105,7 +105,7 @@ func MissingArgumentError(message: String, details: Any?) -> FlutterError {
             result(ret)
         }
     }
-    
+
     func deleteSite(call: FlutterMethodCall, result: @escaping FlutterResult) {
         guard let id = call.arguments as? String else { return result(NoArgumentsError()) }
         //TODO: stop the site if its running currently
@@ -113,19 +113,19 @@ func MissingArgumentError(message: String, details: Any?) -> FlutterError {
             if (error != nil) {
                 result(CallFailedError(message: "Failed to delete site", details: error!.localizedDescription))
             }
-            
+
             result(nil)
         }
     }
-    
+
     func saveSite(call: FlutterMethodCall, result: @escaping FlutterResult) {
         guard let json = call.arguments as? String else { return result(NoArgumentsError()) }
         guard let data = json.data(using: .utf8) else { return result(NoArgumentsError()) }
-        
+
         guard let site = try? JSONDecoder().decode(IncomingSite.self, from: data) else {
             return result(NoArgumentsError())
         }
-        
+
         let oldSite = self.sites?.getSite(id: site.id)
         site.save(manager: oldSite?.manager) { error in
             if (error != nil) {
@@ -135,11 +135,11 @@ func MissingArgumentError(message: String, details: Any?) -> FlutterError {
             result(nil)
         }
     }
-    
+
     func startSite(call: FlutterMethodCall, result: @escaping FlutterResult) {
         guard let args = call.arguments as? Dictionary<String, String> else { return result(NoArgumentsError()) }
         guard let id = args["id"] else { return result(MissingArgumentError(message: "id is a required argument")) }
-        
+
 #if targetEnvironment(simulator)
         let updater = self.sites?.getUpdater(id: id)
         updater?.update(connected: true)
@@ -168,35 +168,35 @@ func MissingArgumentError(message: String, details: Any?) -> FlutterError {
         }
 #endif
     }
-    
+
     func stopSite(call: FlutterMethodCall, result: @escaping FlutterResult) {
         guard let args = call.arguments as? Dictionary<String, String> else { return result(NoArgumentsError()) }
         guard let id = args["id"] else { return result(MissingArgumentError(message: "id is a required argument")) }
 #if targetEnvironment(simulator)
         let updater = self.sites?.getUpdater(id: id)
         updater?.update(connected: false)
-        
+
 #else
         let manager = self.sites?.getSite(id: id)?.manager
         manager?.loadFromPreferences{ error in
             //TODO: Handle load error
-            
+
             manager?.connection.stopVPNTunnel()
             return result(nil)
         }
 #endif
     }
-    
+
     func vpnRequest(command: String, arguments: Any?, result: @escaping FlutterResult) {
         guard let args = arguments as? Dictionary<String, Any> else { return result(NoArgumentsError()) }
         guard let id = args["id"] as? String else { return result(MissingArgumentError(message: "id is a required argument")) }
         let container = sites?.getContainer(id: id)
-        
+
         if container == nil {
             // No site for this id
             return result(nil)
         }
-        
+
         if !(container!.site.connected ?? false) {
             // Site isn't connected, no point in sending a command
             return result(nil)
@@ -208,16 +208,16 @@ func MissingArgumentError(message: String, details: Any?) -> FlutterError {
                     if data == nil {
                         return result(nil)
                     }
-                    
+
                     //print(String(decoding: data!, as: UTF8.self))
                     guard let res = try? JSONDecoder().decode(IPCResponse.self, from: data!) else {
                         return result(CallFailedError(message: "Failed to decode response"))
                     }
-                    
+
                     if res.type == .success {
                         return result(res.message?.object)
                     }
-                    
+
                     return result(CallFailedError(message: res.message?.debugDescription ?? "Failed to convert error"))
                 }
             } catch {

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -8,11 +8,11 @@
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.net.defined.mobileNebula</string>
+		<string>group.org.mooco.mobilenebula</string>
 	</array>
 	<key>keychain-access-groups</key>
 	<array>
-		<string>$(AppIdentifierPrefix)group.net.defined.mobileNebula</string>
+		<string>$(AppIdentifierPrefix)group.org.mooco.mobilenebula</string>
 	</array>
 </dict>
 </plist>

--- a/lib/components/SpecialSelectableText.dart
+++ b/lib/components/SpecialSelectableText.dart
@@ -31,7 +31,7 @@ class _TextSpanEditingController extends TextEditingController {
   final TextSpan _textSpan;
 
   @override
-  TextSpan buildTextSpan({TextStyle style, bool withComposing}) {
+  TextSpan buildTextSpan({BuildContext context, TextStyle style, bool withComposing}) {
     // This does not care about composing.
     return TextSpan(
       style: style,

--- a/lib/models/Site.dart
+++ b/lib/models/Site.dart
@@ -11,7 +11,7 @@ import 'StaticHosts.dart';
 var uuid = Uuid();
 
 class Site {
-  static const platform = MethodChannel('net.defined.mobileNebula/NebulaVpnService');
+  static const platform = MethodChannel('org.mooco.mobilenebula/NebulaVpnService');
   EventChannel _updates;
 
   /// Signals that something about this site has changed. onError is called with an error string if there was an error

--- a/lib/screens/MainScreen.dart
+++ b/lib/screens/MainScreen.dart
@@ -34,7 +34,7 @@ class _MainScreenState extends State<MainScreen> {
   bool ready = false;
   List<Site> sites;
 
-  static const platform = MethodChannel('net.defined.mobileNebula/NebulaVpnService');
+  static const platform = MethodChannel('org.mooco.mobilenebula/NebulaVpnService');
 
   @override
   void initState() {

--- a/lib/screens/SiteDetailScreen.dart
+++ b/lib/screens/SiteDetailScreen.dart
@@ -34,7 +34,7 @@ class SiteDetailScreen extends StatefulWidget {
 class _SiteDetailScreenState extends State<SiteDetailScreen> {
   Site site;
   StreamSubscription onChange;
-  static const platform = MethodChannel('net.defined.mobileNebula/NebulaVpnService');
+  static const platform = MethodChannel('org.mooco.mobilenebula/NebulaVpnService');
   bool changed = false;
   List<HostInfo> activeHosts;
   List<HostInfo> pendingHosts;

--- a/lib/screens/siteConfig/AddCertificateScreen.dart
+++ b/lib/screens/siteConfig/AddCertificateScreen.dart
@@ -44,7 +44,7 @@ class _AddCertificateScreenState extends State<AddCertificateScreen> {
   String inputType = 'paste';
 
   final pasteController = TextEditingController();
-  static const platform = MethodChannel('net.defined.mobileNebula/NebulaVpnService');
+  static const platform = MethodChannel('org.mooco.mobilenebula/NebulaVpnService');
 
   @override
   void initState() {

--- a/lib/screens/siteConfig/CAListScreen.dart
+++ b/lib/screens/siteConfig/CAListScreen.dart
@@ -33,7 +33,7 @@ class _CAListScreenState extends State<CAListScreen> {
   bool changed = false;
   var inputType = "paste";
   final pasteController = TextEditingController();
-  static const platform = MethodChannel('net.defined.mobileNebula/NebulaVpnService');
+  static const platform = MethodChannel('org.mooco.mobilenebula/NebulaVpnService');
   var error = "";
 
   @override

--- a/lib/services/share.dart
+++ b/lib/services/share.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 class Share {
-  static const _channel = MethodChannel('net.defined.mobileNebula/NebulaVpnService');
+  static const _channel = MethodChannel('org.mooco.mobilenebula/NebulaVpnService');
 
   /// Shares a string of text
   /// - title: Title of message or subject if sending an email

--- a/nebula/config.go
+++ b/nebula/config.go
@@ -74,7 +74,13 @@ func newConfig() *config {
 					Host:  "any",
 				},
 			},
-			Inbound: []configFirewallRule{},
+			Inbound: []configFirewallRule{
+        {
+					Port:  "any",
+					Proto: "any",
+					Host:  "any",
+				},
+      },
 		},
 	}
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   barcode_scan:
     dependency: "direct main"
     description:
@@ -244,7 +244,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -279,7 +279,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
Updates the inbound firewall rules to allow all connections, also updates signing and keychain certs to support side loading app until the upstream can support inbound connections or configurable firewall settings in the UI.